### PR TITLE
Fix for null reference exception #69

### DIFF
--- a/src/wallpaper-creator/_mixins/getCovers.js
+++ b/src/wallpaper-creator/_mixins/getCovers.js
@@ -118,12 +118,14 @@ export default {
           browser.storage.local.get( collectionChunkKeys ).then(cData => {
             
             let collections = _.flatMap(cData);
-            let archive = _.find( collections, { id: '__ARCHIVE' });
+            let archive = _.find(collections, {id: '__ARCHIVE'}) ?? {};
             
             callback( archive.books );
             
           });
           
+        } else {
+          callback({});
         }
       });
       


### PR DESCRIPTION
Here's a fix for a null reference exception when opening the wallpaper creator without collections downloaded.